### PR TITLE
Make the error recovery path work back to Julia 1.0

### DIFF
--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -196,7 +196,7 @@ function run_testitem_in_testset(ts, testitem, package_name, test_setup_module_s
         run_testitem(mod, testitem.filename, testitem.option_default_imports, testitem.option_setup, package_name, testitem.code, testitem.line, testitem.column, test_setup_module_set, testsetups)
     catch err
         err isa InterruptException && rethrow()
-        Test.record(ts, Test.Error(:nontest_error, Expr(:tuple), err, Base.current_exceptions(), LineNumberNode(testitem.line, Symbol(testitem.filename))))
+        Test.record(ts, Test.Error(:nontest_error, Expr(:tuple), err, current_exception_stack(), LineNumberNode(testitem.line, Symbol(testitem.filename))))
     end
 
     return
@@ -430,6 +430,36 @@ end
     testset(a...; verbose=false, kw...) = Test.DefaultTestSet(a...; kw...)
 else
     testset(a...; kw...) = Test.DefaultTestSet(a...; kw...)
+end
+
+# `Test.Error` formats the value we pass it with whatever the running Julia
+# version knows how to print: a plain backtrace before v1.2, an exception stack
+# from v1.2 on, which was then renamed from `catch_stack` to `current_exceptions`
+# in v1.7. Note that those two boundaries are not the same version, so this
+# cannot be a two way shim. Each branch passes what that version's own Test
+# stdlib passes when it records an error.
+@static if VERSION ≥ v"1.7"
+    current_exception_stack() = Base.current_exceptions()
+elseif VERSION ≥ v"1.2"
+    current_exception_stack() = Base.catch_stack()
+else
+    current_exception_stack() = catch_backtrace()
+end
+
+@testitem "current_exception_stack" begin
+    using TestItemRunner: current_exception_stack
+
+    stack = try
+        error("boom")
+    catch
+        current_exception_stack()
+    end
+
+    # Test.Error formats the stack when it is constructed, so building one is
+    # what actually shows that we handed it the shape this Julia version wants
+    err = Test.Error(:nontest_error, Expr(:tuple), ErrorException("boom"), stack, LineNumberNode(1, Symbol(@__FILE__)))
+
+    @test err isa Test.Error
 end
 
 end


### PR DESCRIPTION
`Project.toml` declares `julia = "1"`, and CI computes its matrix from that entry with `include-smallest-compatible-minor-versions` on, so it already aims at Julia 1.0. The package did not actually work there.

## Root cause

`run_testitem_in_testset` called `Base.current_exceptions()`, which only exists from Julia 1.7. The module still loaded on older versions and the happy path still ran, so this only surfaced once a test item or a test setup actually threw — at which point the run died with `UndefVarError: current_exceptions not defined` instead of recording the error, and every remaining test item was skipped. Reproduced on 1.0.5 before the fix.

## Why three branches and not two

`Test.Error` started wanting an exception stack rather than a plain backtrace in v1.2, one version *before* `Base.catch_stack` was renamed to `Base.current_exceptions` in v1.7. (`Base.catch_stack` does appear in v1.1, but `Test` there still wants a plain backtrace.) So the two boundaries are at different versions and a two-way shim would be wrong.

| Julia | `Test.jl` does | Needs |
| --- | --- | --- |
| 1.0 – 1.1 | `sprint(showerror, value, bt)` | plain backtrace |
| 1.2 – 1.6 | `sprint(Base.show_exception_stack, bt)` | exception stack |
| 1.7+ | same | `current_exceptions()` |

Each branch of `current_exception_stack` passes exactly what that version's own `Test` stdlib passes when it records an error.

## Test

The shim only runs when a test item throws, which is exactly why the existing suite never touched it. The new test item constructs a `Test.Error` from the result — that construction is the load-bearing part, since it forces the formatting that would fail if the shim returned the wrong shape for the running version.

## No TOML change needed

`TOML` is a stdlib only from 1.6, but it is also a registered package with the same UUID (`fa267f1f-6049-4f14-aa54-33bafae1ed76`) and `julia = "1"` compat, so Pkg resolves the dep to that backport below 1.6 and to the stdlib at or above it.

## Verification

Full test suite, 66 pass / 3 broken on every version:

| Julia | How | Result |
| --- | --- | --- |
| 1.0, 1.1 | suite via `JULIA_LOAD_PATH` | pass |
| 1.2, 1.5 | suite via `JULIA_LOAD_PATH` | pass |
| 1.6, 1.10, 1.12, 1.13 | real `Pkg.test()` | pass |

Old versions used a hand-built load path because Julia 1.0's Pkg does not complete a resolve against the current General registry in any reasonable time; that is a tooling limitation of old Pkg, not of this package.

Error path checked separately on 1.0, 1.1, 1.2, 1.5 and 1.12: a throwing test item and a test item naming an undefined setup are both recorded as errored test items, the other items still run, and the run reaches its summary — identical output on all three shim branches.