### PR TITLE
Release a test item's globals when it finishes

### DIFF
--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -124,6 +124,67 @@ function ensure_setups_evaled(testitem, test_setup_module_set, testsetups)
     end
 end
 
+"""
+    release_module_globals!(mod)
+
+Point every global in `mod` at `nothing`, so that whatever the test item bound to one
+becomes collectable.
+
+Every test item runs in a module of its own, and Julia cannot unload a module: the module
+stays reachable for the life of the process, and so does everything its globals point at.
+A test item that binds a large array therefore keeps that array alive for the rest of the
+run, which is what #65 reports. The module object itself still leaks — nothing can be done
+about that — but its contents do not have to.
+
+Left alone: `eval`, `include` and the module's own name, which the `module` expression
+created rather than the test item, and submodules, because a `@testmodule` reached through
+one is shared with other test items. Bindings that cannot take `nothing` — a `const` on
+Julia before 1.12, a typed global, a name brought in by `using` — are skipped as they come
+up, because there is nothing else to try for them.
+"""
+function release_module_globals!(mod::Module)
+    for name in names(mod; all=true)
+        (name === :eval || name === :include || name === nameof(mod)) && continue
+        # Names Julia generated itself, for closures, generators and macro hygiene
+        occursin('#', string(name)) && continue
+        isdefined(mod, name) || continue
+
+        try
+            getfield(mod, name) isa Module && continue
+            # `Core.eval` rather than `setglobal!`, which only exists from Julia 1.9 on
+            Core.eval(mod, Expr(:(=), name, nothing))
+        catch
+        end
+    end
+
+    return nothing
+end
+
+@testitem "release_module_globals!" begin
+    using TestItemRunner: release_module_globals!
+
+    mod = Core.eval(Main, :(module $(gensym()) end))
+    Base.include_string(mod, "kept = [1, 2, 3]\nconst pinned = 1\n")
+
+    weak = WeakRef(getfield(mod, :kept))
+    release_module_globals!(mod)
+
+    @test getfield(mod, :kept) === nothing
+
+    GC.gc(true)
+    GC.gc(true)
+    @test weak.value === nothing
+
+    # `eval` and `include` belong to the module rather than to the test item
+    @test getfield(mod, :eval) isa Function
+    @test getfield(mod, :include) isa Function
+
+    # A submodule is left alone: a `@testmodule` can be reached through one
+    inner = Core.eval(mod, :(module Inner end))
+    release_module_globals!(mod)
+    @test getfield(mod, :Inner) === inner
+end
+
 function run_testitem(mod, filepath, use_default_usings, setups, package_name, original_code, line, column, test_setup_module_set, testsetups)
     working_dir = dirname(filepath)
 
@@ -180,6 +241,8 @@ function run_testitem_in_testset(ts, testitem, package_name, test_setup_module_s
         return
     end
 
+    mod = nothing
+
     try
         mod = Core.eval(Main, :(module $(gensym()) end))
 
@@ -197,6 +260,11 @@ function run_testitem_in_testset(ts, testitem, package_name, test_setup_module_s
     catch err
         err isa InterruptException && rethrow()
         Test.record(ts, Test.Error(:nontest_error, Expr(:tuple), err, current_exception_stack(), LineNumberNode(testitem.line, Symbol(testitem.filename))))
+    finally
+        # `invokelatest` is load bearing: the test item's globals were created by an
+        # `include_string` in a newer world, and from this one `names(mod; all=true)`
+        # does not list them yet, so a direct call would find nothing to release.
+        mod === nothing || Base.invokelatest(release_module_globals!, mod)
     end
 
     return

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,31 @@ end
     @test false
 end
 
+@testitem "a test item's globals are released once it has run" begin
+    # `run_tests` finishes a root test set, which would otherwise be recorded into the
+    # test set of the test item running it. The test set stack lives in task local
+    # storage and is not inherited, so a fresh task gives the fixture a stack of its own.
+    path = joinpath(@__DIR__, "..", "testdata", "memory")
+
+    printing = Test.TESTSET_PRINT_ENABLE[]
+    Test.TESTSET_PRINT_ENABLE[] = false
+    try
+        task = @async try
+            TestItemRunner.run_tests(path)
+        catch err
+            err
+        end
+        wait(task)
+    finally
+        Test.TESTSET_PRINT_ENABLE[] = printing
+    end
+
+    # The second fixture item is the assertion: it collects and then looks at what the
+    # weak reference the first one parked in `Main` still points at
+    @test isdefined(Main, :TESTITEMRUNNER_MEMORY_PROBE)
+    @test Main.TESTITEMRUNNER_MEMORY_PROBE.value === nothing
+end
+
 @testitem "find_test_files" begin
     using TestItemRunner: find_test_files
 

--- a/testdata/JuliaTestItems.toml
+++ b/testdata/JuliaTestItems.toml
@@ -1,0 +1,11 @@
+# `testdata` holds fixtures that the tests point `run_tests` and `find_test_files`
+# at directly. They are not part of this package's own test suite, and one of them
+# only makes sense as the second half of a pair, so nothing here is searched when
+# the search starts at the repository root.
+#
+# A walk that starts *inside* a fixture folder never sees this file, which is what
+# lets the fixtures still be run on purpose. The folders that carry a config of
+# their own are unaffected either way: the nearest config replaces the one above it
+# wholesale.
+config-version = 1
+exclude = ["**"]

--- a/testdata/memory/tests.jl
+++ b/testdata/memory/tests.jl
@@ -1,0 +1,21 @@
+# Fixture for the test that a test item's globals are released once it finishes.
+#
+# The two items are in one file and in this order, because `run_tests` iterates
+# files in `Dict` order but test items within a file in source order.
+#
+# The probe is parked in `Main` rather than in the item's own module precisely
+# because `Main` is what the teardown does not touch.
+
+@testitem "memory probe: bind" begin
+    leaked = zeros(UInt8, 8_000_000)
+    Core.eval(Main, :(TESTITEMRUNNER_MEMORY_PROBE = $(WeakRef(leaked))))
+    @test length(leaked) == 8_000_000
+end
+
+@testitem "memory probe: check" begin
+    GC.gc(true)
+    GC.gc(true)
+
+    @test isdefined(Main, :TESTITEMRUNNER_MEMORY_PROBE)
+    @test Main.TESTITEMRUNNER_MEMORY_PROBE.value === nothing
+end


### PR DESCRIPTION
Closes #65. The TestItemControllers half — the same fix for the VS Code / `juliati` test process — is julia-testitems/TestItemControllers.jl#60.

Every test item runs in a module of its own, and Julia cannot unload a module: the module stays reachable for the life of the process, and so does everything the item bound to a global. Running `@run_package_tests` a few times over an item like the reporter's

```julia
@testitem "tt" begin
    a = ones(1000, 1000, 1000)
end
```

therefore fills memory, and setting `a = nothing` by hand is the only thing that helps today.

The module object itself still leaks; nothing can be done about that. Its contents do not have to. Once the item is done, `release_module_globals!` points every global in its module at `nothing`.

Left alone:
- `eval`, `include` and the module's own name — the `module` expression created those, not the test item;
- submodules, because a `@testmodule` reached through one is shared with other test items;
- bindings that cannot take `nothing` (a `const` on Julia before 1.12, a typed global, a name brought in by `using`) — skipped as they come up, since there is nothing else to try for them.

Worth flagging for review: the teardown has to go through `invokelatest`. The item's globals are created by an `include_string` in a newer world, and from the world `run_testitem_in_testset` runs in, `names(mod; all=true)` does not list them yet — a direct call finds nothing to release and silently does nothing.

Two tests: a unit test of `release_module_globals!` next to it in `src/`, and an end-to-end one that runs the new `testdata/memory` fixture. The fixture's first item parks a `WeakRef` to an 8 MB array in `Main` — `Main` is not a test code module, so the teardown leaves the probe alone — and its second item collects and checks the reference has gone dead. I confirmed the end-to-end test fails when the teardown is removed.

The new `testdata/JuliaTestItems.toml` keeps the fixtures out of this package's own test run: the second fixture item only makes sense as the other half of a pair. A walk that starts inside a fixture folder never sees that file, which is what lets the fixture still be run on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
