### PR TITLE
Compose JuliaTestItems.toml scope over the whole ancestor chain

### DIFF
--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -224,7 +224,9 @@ items.
 
 Version control and dependency folders are never descended into, and any
 `JuliaTestItems.toml` file that is found scopes which of the remaining files are
-searched, see [`testitems_selected`](@ref).
+searched, see [`testitems_selected`](@ref). Config files in the directories
+*above* `path` count too, so that searching a subdirectory directly honours the
+same exclusions as searching the whole project.
 """
 function find_test_files(path)
     path = abspath(path)
@@ -271,11 +273,35 @@ function find_test_files(path)
         end
     end
 
+    # Scope is the intersection over every enclosing config file, so the ones
+    # above `path` matter as much as the ones inside it — otherwise running the
+    # tests of a vendored subpackage directly would see a different set of test
+    # items than the language server shows for the whole project.
+    append!(config_files, _enclosing_config_files(path))
+
     isempty(config_files) && return julia_files
 
     configs = Dict{String,PathFilter}(i => parse_testitems_config(i) for i in config_files)
 
     return Base.filter(i -> testitems_selected(configs, i), julia_files)
+end
+
+# Every `JuliaTestItems.toml` in a strict ancestor directory of `dir`, walking up
+# to the filesystem root.
+function _enclosing_config_files(dir)
+    res = String[]
+
+    current = dirname(dir)
+    while true
+        candidate = joinpath(current, "JuliaTestItems.toml")
+        isfile(candidate) && push!(res, normpath(candidate))
+
+        parent = dirname(current)
+        parent == current && break
+        current = parent
+    end
+
+    return res
 end
 
 """

--- a/src/testitems_config.jl
+++ b/src/testitems_config.jl
@@ -9,7 +9,13 @@
 #
 # Keeping the semantics identical to JuliaWorkspaces matters, because the same
 # config file decides which test items VS Code shows and which test items
-# `@run_package_tests` runs.
+# `@run_package_tests` runs. In particular, scope is the intersection over the
+# whole chain of enclosing config files: a nested `JuliaTestItems.toml` may
+# narrow discovery further, but it can never resurrect a subtree an enclosing
+# config excluded. `find_test_files` therefore also collects config files in the
+# directories *above* the tree it is asked to search, so that running the tests
+# of a vendored subpackage directly sees the same exclusions the language server
+# does.
 
 # ── Glob matching ───────────────────────────────────────────────────────────
 
@@ -173,27 +179,35 @@ function is_testitems_config_file(path)
 end
 
 """
-    nearest_config(config_paths, path) -> Union{String,Nothing}
+    ancestor_configs(config_paths, path) -> Vector{String}
 
-The config file governing `path`: the one in the deepest directory that is a
-prefix of `path`'s directory. Only that single file applies — a nested config
-file replaces the one above it rather than adding to it.
+Every config file whose directory is a prefix of `path`, outermost first. Scope
+is the intersection over this whole chain, see [`testitems_selected`](@ref).
 """
-function nearest_config(config_paths, path::AbstractString)
+function ancestor_configs(config_paths, path::AbstractString)
     target = replace(String(path), '\\' => '/')
 
-    best = nothing
-    best_len = -1
+    res = Tuple{Int,String}[]
     for config_path in config_paths
         dir = _normalize_dir(dirname(config_path))
         _path_startswith(target, dir) || continue
-        if length(dir) > best_len
-            best = config_path
-            best_len = length(dir)
-        end
+        push!(res, (length(dir), config_path))
     end
+    sort!(res)
 
-    return best
+    return String[x[2] for x in res]
+end
+
+"""
+    nearest_config(config_paths, path) -> Union{String,Nothing}
+
+The innermost config file enclosing `path`, or `nothing` when there is none.
+Scope does not come from this one file alone — see [`ancestor_configs`](@ref).
+"""
+function nearest_config(config_paths, path::AbstractString)
+    chain = ancestor_configs(config_paths, path)
+
+    return isempty(chain) ? nothing : last(chain)
 end
 
 # ── Parsing ─────────────────────────────────────────────────────────────────
@@ -249,20 +263,22 @@ end
 """
     testitems_selected(configs, path) -> Bool
 
-Whether `path` is searched for test items, according to the `JuliaTestItems.toml`
-governing it. `configs` maps the path of each config file that was found to its
-parsed [`PathFilter`](@ref). A file with no governing config file is selected.
+Whether `path` is searched for test items. Every `JuliaTestItems.toml` enclosing
+`path` must admit it, each evaluated relative to its own directory, so a nested
+config can narrow discovery further but never widen it. `configs` maps the path
+of each config file that was found to its parsed [`PathFilter`](@ref). A file
+with no enclosing config file is selected.
 """
 function testitems_selected(configs, path::AbstractString)
     isempty(configs) && return true
 
-    config_path = nearest_config(keys(configs), path)
-    config_path === nothing && return true
+    for config_path in ancestor_configs(keys(configs), path)
+        relative_path = config_relative_path(dirname(config_path), path)
+        relative_path === nothing && continue
+        path_selected(configs[config_path], relative_path) || return false
+    end
 
-    relative_path = config_relative_path(dirname(config_path), path)
-    relative_path === nothing && return true
-
-    return path_selected(configs[config_path], relative_path)
+    return true
 end
 
 @testitem "glob patterns" begin
@@ -328,18 +344,27 @@ end
     @test !path_selected(both, "test/manual/foo.jl")
 end
 
-@testitem "nearest_config" begin
-    using TestItemRunner: nearest_config, config_relative_path
+@testitem "ancestor_configs" begin
+    using TestItemRunner: ancestor_configs, nearest_config, config_relative_path
 
     configs = ["/a/JuliaTestItems.toml", "/a/b/c/JuliaTestItems.toml"]
 
-    # The deepest enclosing config file wins.
-    @test nearest_config(configs, "/a/foo.jl") == "/a/JuliaTestItems.toml"
-    @test nearest_config(configs, "/a/b/foo.jl") == "/a/JuliaTestItems.toml"
-    @test nearest_config(configs, "/a/b/c/foo.jl") == "/a/b/c/JuliaTestItems.toml"
-    @test nearest_config(configs, "/a/b/c/d/foo.jl") == "/a/b/c/JuliaTestItems.toml"
+    # Every enclosing config file, outermost first.
+    @test ancestor_configs(configs, "/a/foo.jl") == ["/a/JuliaTestItems.toml"]
+    @test ancestor_configs(configs, "/a/b/foo.jl") == ["/a/JuliaTestItems.toml"]
+    @test ancestor_configs(configs, "/a/b/c/foo.jl") == configs
+    @test ancestor_configs(configs, "/a/b/c/d/foo.jl") == configs
+
+    # The order of the input does not change the result.
+    @test ancestor_configs(reverse(configs), "/a/b/c/foo.jl") == configs
 
     # A file outside of every config file's directory has no config.
+    @test isempty(ancestor_configs(configs, "/z/foo.jl"))
+    @test isempty(ancestor_configs(String[], "/a/foo.jl"))
+
+    # `nearest_config` is the innermost entry of the same chain.
+    @test nearest_config(configs, "/a/b/foo.jl") == "/a/JuliaTestItems.toml"
+    @test nearest_config(configs, "/a/b/c/d/foo.jl") == "/a/b/c/JuliaTestItems.toml"
     @test nearest_config(configs, "/z/foo.jl") === nothing
     @test nearest_config(String[], "/a/foo.jl") === nothing
 
@@ -355,17 +380,36 @@ end
     # A file with no config file anywhere above it is selected.
     @test testitems_selected(Dict{String,PathFilter}(), "/a/foo.jl")
 
+    # Note the exclusion is written relative to `/a`, the directory of the
+    # config file that carries it: a pattern containing a separator is anchored
+    # there, so `gen/**` alone would not reach `/a/b/gen`.
     configs = Dict(
-        "/a/JuliaTestItems.toml" => PathFilter(GlobPattern[], [GlobPattern("gen/**")]),
+        "/a/JuliaTestItems.toml" => PathFilter(GlobPattern[], [GlobPattern("b/gen/**")]),
         "/a/b/JuliaTestItems.toml" => PathFilter(GlobPattern[], GlobPattern[])
     )
 
     @test testitems_selected(configs, "/a/foo.jl")
-    @test !testitems_selected(configs, "/a/gen/foo.jl")
+    @test testitems_selected(configs, "/a/b/foo.jl")
 
-    # The nearest config replaces the one above it wholesale, so the `gen`
-    # exclusion of `/a` does not apply below `/a/b`.
-    @test testitems_selected(configs, "/a/b/gen/foo.jl")
+    # An enclosing config's exclusion holds even where a nested config takes
+    # over: a nested file can narrow discovery, never widen it.
+    @test !testitems_selected(configs, "/a/b/gen/foo.jl")
+
+    # A nested config may still narrow further.
+    narrowing = Dict(
+        "/a/JuliaTestItems.toml" => PathFilter(GlobPattern[], GlobPattern[]),
+        "/a/b/JuliaTestItems.toml" => PathFilter(GlobPattern[], [GlobPattern("gen/**")])
+    )
+    @test testitems_selected(narrowing, "/a/b/src/foo.jl")
+    @test !testitems_selected(narrowing, "/a/b/gen/foo.jl")
+
+    # A nested `include` cannot widen the enclosing one.
+    widening = Dict(
+        "/a/JuliaTestItems.toml" => PathFilter([GlobPattern("b/src/**")], GlobPattern[]),
+        "/a/b/JuliaTestItems.toml" => PathFilter([GlobPattern("**")], GlobPattern[])
+    )
+    @test testitems_selected(widening, "/a/b/src/foo.jl")
+    @test !testitems_selected(widening, "/a/b/docs/foo.jl")
 
     @test testitems_selected(configs, "/z/foo.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,10 +50,18 @@ end
     # Folders like node_modules are never descended into
     @test !("node_modules/ignored.jl" in files)
 
-    # The nearest JuliaTestItems.toml replaces the one above it wholesale, so
-    # the `excluded/**` exclusion does not apply below `nested`
+    # A nested JuliaTestItems.toml governs the settings below it, and its
+    # folder is still searched
     @test "nested/nested_included.jl" in files
+
+    # The root's `excluded/**` is anchored to the root of the fixture, so it
+    # matches `excluded/` there but not `nested/excluded/` further down
     @test "nested/excluded/nested_excluded.jl" in files
+
+    # But what the root DOES exclude stays excluded: scope is the intersection
+    # over every enclosing config file, so the JuliaTestItems.toml in `nested`
+    # cannot bring `nested/vetoed` back
+    @test !("nested/vetoed/vetoed.jl" in files)
 
     @test length(files) == 3
 end

--- a/testdata/testitemsconfig/JuliaTestItems.toml
+++ b/testdata/testitemsconfig/JuliaTestItems.toml
@@ -1,2 +1,5 @@
 config-version = 1
-exclude = ["excluded/**"]
+# Both patterns are anchored to this folder, the one holding the config file.
+# `nested/vetoed/**` reaches into a folder that has its own JuliaTestItems.toml
+# above it, and stays excluded regardless.
+exclude = ["excluded/**", "nested/vetoed/**"]

--- a/testdata/testitemsconfig/nested/JuliaTestItems.toml
+++ b/testdata/testitemsconfig/nested/JuliaTestItems.toml
@@ -1,3 +1,5 @@
-# This file replaces the one in the parent folder for everything below this
-# folder, rather than adding to it, so the `excluded` folder next to it is
-# searched for test items.
+# This file governs the settings of everything below this folder, but scope is
+# the intersection with every config file above it. So `nested/excluded` IS
+# searched — the parent's `excluded/**` is anchored to the parent folder and
+# never reached it — while `nested/vetoed` is NOT, because the parent excludes
+# it by name and a nested config can only narrow scope, never widen it.

--- a/testdata/testitemsconfig/nested/excluded/nested_excluded.jl
+++ b/testdata/testitemsconfig/nested/excluded/nested_excluded.jl
@@ -1,2 +1,3 @@
-# A fixture file that is selected despite its folder name, because the nearest
-# JuliaTestItems.toml replaces the one further up that excludes `excluded/**`.
+# A fixture file that is selected despite its folder name: the `excluded/**`
+# pattern in the JuliaTestItems.toml further up is anchored to that file's own
+# folder, so it matches `excluded/` there but not `nested/excluded/` here.

--- a/testdata/testitemsconfig/nested/vetoed/vetoed.jl
+++ b/testdata/testitemsconfig/nested/vetoed/vetoed.jl
@@ -1,0 +1,3 @@
+# A fixture file that is NOT selected: the JuliaTestItems.toml at the root of
+# this fixture excludes `nested/vetoed/**`, and the nested config file above
+# this folder cannot take that back.


### PR DESCRIPTION
Paired with julia-vscode/JuliaWorkspaces.jl#265 — **these two should merge together**, since `src/testitems_config.jl` promises identical semantics to JuliaWorkspaces and that promise would otherwise be false on `main`.

## The problem

`nearest_config` picked the deepest `JuliaTestItems.toml` enclosing a file, and that one file decided everything — including whether the file was searched at all. No enclosing config was ever consulted.

So a vendored package shipping its own `JuliaTestItems.toml` resurrected a subtree the vendoring project had deliberately excluded, and there was no way for the parent to say otherwise. Vendored code effectively held a veto over the project vendoring it.

## The change

Scope is now the intersection over **every** enclosing config file, each evaluated relative to its own directory:

> A nested config may narrow discovery further, but never widen it.

This is the rule git applies to `.gitignore` ("it is not possible to re-include a file if a parent directory is excluded"), and the same split Ruff makes between hierarchical rule settings and top-level file discovery.

`find_test_files` now also collects config files in the directories *above* the tree it searches. Without that, `@run_package_tests` pointed at a subdirectory would miss exclusions the language server applies, and the two would disagree about which test items exist.

## A note on the tests that were "covering" this

The existing `testitems_selected` test looked like it pinned the old behavior:

```julia
# The nearest config replaces the one above it wholesale, so the `gen`
# exclusion of `/a` does not apply below `/a/b`.
@test testitems_selected(configs, "/a/b/gen/foo.jl")
```

It did not. `gen/**` contains a separator, so it is anchored to its config file's directory and compiles to `^gen/.*$` — it never matched `/a/b/gen/foo.jl` under either rule. The `testdata/testitemsconfig` fixture had the same problem, and its comments named the wrong cause.

Both are rewritten so they genuinely discriminate: the fixture gains `nested/vetoed/`, excluded by name from the root config and sitting under a nested config that would previously have reclaimed it.

## Verification

Full suite green (76 passed, 3 broken as before). The new fixture case fails on `main` and passes here.