### PR TITLE
Scope test item discovery to the folder the search starts in

### DIFF
--- a/src/TestItemRunner.jl
+++ b/src/TestItemRunner.jl
@@ -351,9 +351,9 @@ items.
 
 Version control and dependency folders are never descended into, and any
 `JuliaTestItems.toml` file that is found scopes which of the remaining files are
-searched, see [`testitems_selected`](@ref). Config files in the directories
-*above* `path` count too, so that searching a subdirectory directly honours the
-same exclusions as searching the whole project.
+searched, see [`testitems_selected`](@ref). `path` is the root of that scope:
+config files above it are not consulted, just as the language server consults
+none above a workspace folder.
 """
 function find_test_files(path)
     path = abspath(path)
@@ -400,35 +400,11 @@ function find_test_files(path)
         end
     end
 
-    # Scope is the intersection over every enclosing config file, so the ones
-    # above `path` matter as much as the ones inside it — otherwise running the
-    # tests of a vendored subpackage directly would see a different set of test
-    # items than the language server shows for the whole project.
-    append!(config_files, _enclosing_config_files(path))
-
     isempty(config_files) && return julia_files
 
     configs = Dict{String,PathFilter}(i => parse_testitems_config(i) for i in config_files)
 
     return Base.filter(i -> testitems_selected(configs, i), julia_files)
-end
-
-# Every `JuliaTestItems.toml` in a strict ancestor directory of `dir`, walking up
-# to the filesystem root.
-function _enclosing_config_files(dir)
-    res = String[]
-
-    current = dirname(dir)
-    while true
-        candidate = joinpath(current, "JuliaTestItems.toml")
-        isfile(candidate) && push!(res, normpath(candidate))
-
-        parent = dirname(current)
-        parent == current && break
-        current = parent
-    end
-
-    return res
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,6 +132,19 @@ end
     @test !("nested/vetoed/vetoed.jl" in files)
 
     @test length(files) == 3
+
+    # The search is scoped by the folder it starts in: config files above that
+    # folder are not consulted, so starting inside `nested` no longer sees the
+    # `nested/vetoed/**` exclusion of the config one level up. This is also what
+    # keeps `testdata/JuliaTestItems.toml`, which excludes everything, from
+    # hiding the fixtures the tests point at directly.
+    nested = joinpath(path, "nested")
+    nested_files = [replace(relpath(i, nested), '\\' => '/') for i in find_test_files(nested)]
+
+    @test "vetoed/vetoed.jl" in nested_files
+    @test "nested_included.jl" in nested_files
+    @test "excluded/nested_excluded.jl" in nested_files
+    @test length(nested_files) == 3
 end
 
 dir = pwd()

--- a/testdata/JuliaTestItems.toml
+++ b/testdata/JuliaTestItems.toml
@@ -3,9 +3,8 @@
 # only makes sense as the second half of a pair, so nothing here is searched when
 # the search starts at the repository root.
 #
-# A walk that starts *inside* a fixture folder never sees this file, which is what
-# lets the fixtures still be run on purpose. The folders that carry a config of
-# their own are unaffected either way: the nearest config replaces the one above it
-# wholesale.
+# A search is scoped by the folder it starts in, so a walk that starts *inside* a
+# fixture folder never sees this file, which is what lets the tests still point at
+# the fixtures on purpose.
 config-version = 1
 exclude = ["**"]


### PR DESCRIPTION
CI on `main` is red on every platform: four test items fail — `find_test_files`, `a test item's globals are released once it has run`, and both `failfast` items.

## The problem

#136 made `find_test_files` collect config files in the directories *above* the tree it searches, walking to the filesystem root. Combined with #134/#135, which put `exclude = ["**"]` in `testdata/JuliaTestItems.toml` so the fixtures stay out of a search that starts at the repository root, that removed the only way to run them: the tests point `run_tests`/`find_test_files` straight at `testdata/failfast`, `testdata/memory`, `testdata/testitemsconfig`, and the walk now climbs past those folders and picks up the blanket exclusion. Every fixture resolves to zero files.

That was not visible when #136 was reviewed because #134/#135 landed alongside it.

## The change

The path handed to `find_test_files` is the root of the config scope. Inside it nothing changes — scope is still the intersection over every enclosing config file, so a nested config narrows discovery and can never widen it, which is the veto #136 added. Above it, config files are not consulted.

This is also what the language server does: `derived_testitems_selected` in JuliaWorkspaces chains the config files known to the workspace, and a workspace never contains files above its own folders. And it is the rule git applies to `.gitignore` — relative to a repository root, not to `/`.

## Tests

`find_test_files` gains a second search rooted at `testitemsconfig/nested`, which finds `nested/vetoed/vetoed.jl` precisely because the `nested/vetoed/**` exclusion one level up is now out of scope. That case fails without this change.

Full suite green locally (16 passed, 3 skip-items; the four failing items on `main` all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)