### PR TITLE
Correct the ported-semantics note about where scope starts

### DIFF
--- a/src/testitems_config.jl
+++ b/src/testitems_config.jl
@@ -12,10 +12,10 @@
 # `@run_package_tests` runs. In particular, scope is the intersection over the
 # whole chain of enclosing config files: a nested `JuliaTestItems.toml` may
 # narrow discovery further, but it can never resurrect a subtree an enclosing
-# config excluded. `find_test_files` therefore also collects config files in the
-# directories *above* the tree it is asked to search, so that running the tests
-# of a vendored subpackage directly sees the same exclusions the language server
-# does.
+# config excluded. Each side roots that chain at the tree it is given — a
+# workspace folder for the language server, `path` for `find_test_files` — so
+# pointing the runner at a subdirectory scopes discovery to that subdirectory,
+# exactly as opening it as a workspace folder would.
 
 # ── Glob matching ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Loose end from #137. The header comment in `src/testitems_config.jl` still ends with:

> `find_test_files` therefore also collects config files in the directories *above* the tree it is asked to search, so that running the tests of a vendored subpackage directly sees the same exclusions the language server does.

#137 removed exactly that behavior, and the `find_test_files` docstring already says so. The rest of the paragraph stands — scope is still the intersection over the chain of enclosing config files, which is the point of keeping this a faithful port — so only the sentence about where the chain starts changes.

Paired with julia-vscode/JuliaWorkspaces.jl#267, which fixes the mirror-image claim in the JuliaWorkspaces configuration docs.

Comment only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)